### PR TITLE
Use nexus as fallback rather than primary repo

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=http://nexus.liquorice.io:8081/repository/public/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
-wrapperUrl=http://nexus.liquorice.io:8081/repository/public/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
   - os: linux
     jdk: openjdk8
 
-env:
-  MVNW_REPOURL: http://nexus.liquorice.io:8081/repository/public
-
 install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --settings maven-settings.xml
 
 script: ./mvnw clean verify -Pcode-coverage,integration-tests,static-code-analysis --settings maven-settings.xml

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -10,7 +10,17 @@
       <repositories>
         <repository>
           <id>central</id>
-          <url>http://central</url>
+          <url>http://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>liquorice.nexus</id>
+          <url>http://nexus.liquorice.io:8081/repository/maven-releases</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -22,7 +32,7 @@
       <pluginRepositories>
         <pluginRepository>
           <id>central</id>
-          <url>http://central</url>
+          <url>http://repo1.maven.org/maven2</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -33,22 +43,6 @@
       </pluginRepositories>
     </profile>
   </profiles>
-
-  <mirrors>
-    <mirror>
-      <id>liquorice.nexus</id>
-      <mirrorOf>*</mirrorOf>
-      <url>http://nexus.liquorice.io:8081/repository/public</url>
-    </mirror>
-  </mirrors>
-
-  <servers>
-    <server>
-      <id>liquorice.nexus</id>
-      <username>admin</username>
-      <password>admin123</password>
-    </server>
-  </servers>
 
   <activeProfiles>
     <activeProfile>liquorice.nexus</activeProfile>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.liquorice</groupId>
         <artifactId>maven-parent-poms</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
     <groupId>io.liquorice.config</groupId>


### PR DESCRIPTION
Rather than trying to pull everything from the nexus repo, instead pull everything from central and only fallback to nexus for unresolvable dependencies.