### PR TITLE
Upgrade to java11 and remove guava

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
 dist: trusty
 language: java
 sudo: false
+jdk:
+  - openjdk11
 
-matrix:
-  include:
-  - os: linux
-    jdk: oraclejdk8
-  - os: linux
-    jdk: openjdk8
+# Only build master and pull requests
+branches:
+  only:
+    - master
 
 install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script: ./mvnw clean verify -Dfull-build
+
+# Only deploy artifacts to nexus if master changes
+deploy:
+  - provider: script
+    script: ./mvnw clean deploy -DskipTests=true
+    on:
+      branch: master
 
 notifications:
   slack:

--- a/config-api/src/main/java/io/liquorice/config/api/storage/AbstractConfigSpace.java
+++ b/config-api/src/main/java/io/liquorice/config/api/storage/AbstractConfigSpace.java
@@ -1,6 +1,6 @@
 package io.liquorice.config.api.storage;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.exception.ConfigurationException;
@@ -12,7 +12,7 @@ import io.liquorice.config.exception.ConfigurationException;
  */
 public abstract class AbstractConfigSpace implements ConfigSpace {
 
-    private ConfigFormatter configFormatter;
+    private final ConfigFormatter configFormatter;
 
     /**
      * CTOR
@@ -21,7 +21,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      *            the {@link ConfigFormatter} to use for retrieivng properties
      */
     public AbstractConfigSpace(final ConfigFormatter configFormatter) {
-        checkNotNull(configFormatter, "Config formatter cannot be null");
+        requireNonNull(configFormatter, "Config formatter cannot be null");
         this.configFormatter = configFormatter;
     }
 
@@ -30,7 +30,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      */
     @Override
     public boolean getBoolean(final String key, final boolean defaultValue) {
-        checkNotNull(key, "Key cannot be null");
+        requireNonNull(key, "Key cannot be null");
         try {
             return hasValue(key) ? getBooleanRequired(key) : defaultValue;
         } catch (final Exception e) {
@@ -48,7 +48,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      */
     @Override
     public double getDouble(final String key, final double defaultValue) {
-        checkNotNull(key, "Key cannot be null");
+        requireNonNull(key, "Key cannot be null");
         try {
             return hasValue(key) ? getDoubleRequired(key) : defaultValue;
         } catch (final Exception e) {
@@ -66,7 +66,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      */
     @Override
     public int getInt(final String key, final int defaultValue) {
-        checkNotNull(key, "Key cannot be null");
+        requireNonNull(key, "Key cannot be null");
         try {
             return hasValue(key) ? getIntRequired(key) : defaultValue;
         } catch (final Exception e) {
@@ -84,7 +84,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      */
     @Override
     public long getLong(final String key, final long defaultValue) {
-        checkNotNull(key, "Key cannot be null");
+        requireNonNull(key, "Key cannot be null");
         try {
             return hasValue(key) ? getLongRequired(key) : defaultValue;
         } catch (final Exception e) {
@@ -102,7 +102,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      */
     @Override
     public <T> T getObject(final String key, final T defaultValue, final Class<T> clazz) {
-        checkNotNull(key, "Key cannot be null");
+        requireNonNull(key, "Key cannot be null");
         try {
             return hasValue(key) ? getObjectRequired(key, clazz) : defaultValue;
         } catch (final Exception e) {
@@ -120,7 +120,7 @@ public abstract class AbstractConfigSpace implements ConfigSpace {
      */
     @Override
     public String getString(final String key, final String defaultValue) {
-        checkNotNull(key, "Key cannot be null");
+        requireNonNull(key, "Key cannot be null");
         try {
             return hasValue(key) ? getStringRequired(key) : defaultValue;
         } catch (final Exception e) {

--- a/config-exceptions/pom.xml
+++ b/config-exceptions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>config-exceptions</artifactId>

--- a/formatter-json-gson/pom.xml
+++ b/formatter-json-gson/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>formatter-json-gson</artifactId>
@@ -16,11 +16,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/formatter-json-gson/src/main/java/io/liquorice/config/formatter/json/gson/GsonConfigFormatter.java
+++ b/formatter-json-gson/src/main/java/io/liquorice/config/formatter/json/gson/GsonConfigFormatter.java
@@ -1,16 +1,16 @@
 package io.liquorice.config.formatter.json.gson;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -26,7 +26,7 @@ public class GsonConfigFormatter implements StreamableConfigFormatter {
 
     private static final GsonBuilder DEFAULT_GSON_BUILDER = new GsonBuilder();
 
-    private Gson gson;
+    private final Gson gson;
 
     /**
      * CTOR
@@ -70,7 +70,7 @@ public class GsonConfigFormatter implements StreamableConfigFormatter {
      */
     @Override
     public <T> Optional<T> read(final InputStream inputStream, final Class<T> valueType) {
-        return read(new InputStreamReader(inputStream, Charsets.UTF_8), valueType);
+        return read(new InputStreamReader(inputStream, StandardCharsets.UTF_8), valueType);
     }
 
     /**
@@ -126,7 +126,7 @@ public class GsonConfigFormatter implements StreamableConfigFormatter {
          */
         public Builder() {
             this.gsonBuilder = DEFAULT_GSON_BUILDER;
-            this.typeAdapters = Maps.newHashMap();
+            this.typeAdapters = new HashMap<>();
         }
 
         /**
@@ -173,9 +173,9 @@ public class GsonConfigFormatter implements StreamableConfigFormatter {
          * @return a new {@link GsonConfigFormatter} built to specification
          */
         public GsonConfigFormatter build() {
-            checkNotNull(gsonBuilder);
+            requireNonNull(gsonBuilder);
             for (final Map.Entry<Type, Object> entry : typeAdapters.entrySet()) {
-                this.gsonBuilder.registerTypeAdapter(checkNotNull(entry.getKey()), checkNotNull(entry.getValue()));
+                this.gsonBuilder.registerTypeAdapter(requireNonNull(entry.getKey()), requireNonNull(entry.getValue()));
             }
 
             return new GsonConfigFormatter(this);

--- a/formatter-json-gson/src/test/java/io/liquorice/config/formatter/json/gson/GsonConfigFormatterTest.java
+++ b/formatter-json-gson/src/test/java/io/liquorice/config/formatter/json/gson/GsonConfigFormatterTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonPrimitive;
@@ -56,58 +56,56 @@ class GsonConfigFormatterTest {
     }
 
     @Test
-    void testReadObjectIsInputStream() throws Exception {
-        final Object downcastedInputStream = new ByteArrayInputStream(TEST_JSON.getBytes(Charsets.UTF_8));
+    void testReadObjectIsInputStream() {
+        final Object downcastedInputStream = new ByteArrayInputStream(TEST_JSON.getBytes(StandardCharsets.UTF_8));
         assertEquals(TEST_MAP, configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsMalformedInputStreamContent() throws Exception {
-        final Object downcastedInputStream = new ByteArrayInputStream(TEST_NOT_JSON.getBytes(Charsets.UTF_8));
+    void testReadObjectIsMalformedInputStreamContent() {
+        final Object downcastedInputStream = new ByteArrayInputStream(TEST_NOT_JSON.getBytes(StandardCharsets.UTF_8));
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsReader() throws Exception {
+    void testReadObjectIsReader() {
         final Object downcastedInputStream = new InputStreamReader(new ByteArrayInputStream(
-                TEST_JSON.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+                TEST_JSON.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals(TEST_MAP, configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsMalformedReaderContent() throws Exception {
+    void testReadObjectIsMalformedReaderContent() {
         final Object downcastedInputStream = new InputStreamReader(new ByteArrayInputStream(
-                TEST_NOT_JSON.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+                TEST_NOT_JSON.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsString() throws Exception {
-        final Object downcastedString = TEST_JSON;
-        assertEquals(TEST_MAP, configFormatter.read(downcastedString, Map.class).get());
+    void testReadObjectIsString() {
+        assertEquals(TEST_MAP, configFormatter.read(TEST_JSON, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsMalformedStringContent() throws Exception {
-        final Object downcastedString = TEST_NOT_JSON;
-        assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedString, Map.class).get());
+    void testReadObjectIsMalformedStringContent() {
+        assertThrows(NoSuchElementException.class, () -> configFormatter.read(TEST_NOT_JSON, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsJsonElement() throws Exception {
+    void testReadObjectIsJsonElement() {
         final Object jsonElement = new JsonPrimitive(TEST_VALUE);
         final String read = configFormatter.read(jsonElement, String.class).get();
         assertEquals(TEST_VALUE, read);
     }
 
     @Test
-    void testUnsupportedInputType() throws Exception {
+    void testUnsupportedInputType() {
         final Object downcastedDouble = 2.0;
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedDouble, Map.class).get());
     }
 
     @Test
-    void testWrite() throws Exception {
+    void testWrite() {
         final Object written = configFormatter.write(TEST_MAP);
         assertTrue(written instanceof String);
         assertEquals(TEST_JSON, written);

--- a/formatter-json-jackson/pom.xml
+++ b/formatter-json-jackson/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>formatter-json-jackson</artifactId>
@@ -21,11 +21,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/formatter-json-jackson/src/main/java/io/liquorice/config/formatter/json/jackson/JacksonConfigFormatter.java
+++ b/formatter-json-jackson/src/main/java/io/liquorice/config/formatter/json/jackson/JacksonConfigFormatter.java
@@ -1,10 +1,11 @@
 package io.liquorice.config.formatter.json.jackson;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
@@ -110,7 +111,7 @@ public class JacksonConfigFormatter implements StreamableConfigFormatter {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (final JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -149,7 +150,7 @@ public class JacksonConfigFormatter implements StreamableConfigFormatter {
          * @return this
          */
         public Builder withRegisteredModule(final Module module) {
-            this.modulesToRegister.add(checkNotNull(module));
+            this.modulesToRegister.add(requireNonNull(module));
             return this;
         }
 
@@ -161,7 +162,7 @@ public class JacksonConfigFormatter implements StreamableConfigFormatter {
          * @return this
          */
         public Builder withRegisteredModules(final Collection<Module> modules) {
-            this.modulesToRegister.addAll(checkNotNull(modules));
+            this.modulesToRegister.addAll(requireNonNull(modules));
             return this;
         }
 
@@ -171,9 +172,9 @@ public class JacksonConfigFormatter implements StreamableConfigFormatter {
          * @return a new {@link JacksonConfigFormatter} built to specification
          */
         public JacksonConfigFormatter build() {
-            checkNotNull(objectMapper);
+            requireNonNull(objectMapper);
             for (final Module module : modulesToRegister) {
-                this.objectMapper.registerModule(checkNotNull(module));
+                this.objectMapper.registerModule(requireNonNull(module));
             }
             return new JacksonConfigFormatter(this);
         }

--- a/formatter-json-jackson/src/test/java/io/liquorice/config/formatter/json/jackson/JacksonConfigFormatterTest.java
+++ b/formatter-json-jackson/src/test/java/io/liquorice/config/formatter/json/jackson/JacksonConfigFormatterTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -27,7 +28,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.base.Charsets;
 
 /**
  * Created by mthorpe on 12/11/16.
@@ -55,43 +55,43 @@ class JacksonConfigFormatterTest {
     }
 
     @Test
-    void testReadObjectIsInputStream() throws Exception {
-        final Object downcastedInputStream = new ByteArrayInputStream(TEST_JSON.getBytes(Charsets.UTF_8));
+    void testReadObjectIsInputStream() {
+        final Object downcastedInputStream = new ByteArrayInputStream(TEST_JSON.getBytes(StandardCharsets.UTF_8));
         assertEquals(TEST_MAP, configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsMalformedInputStreamContent() throws Exception {
-        final Object downcastedInputStream = new ByteArrayInputStream(TEST_NOT_JSON.getBytes(Charsets.UTF_8));
+    void testReadObjectIsMalformedInputStreamContent() {
+        final Object downcastedInputStream = new ByteArrayInputStream(TEST_NOT_JSON.getBytes(StandardCharsets.UTF_8));
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsReader() throws Exception {
+    void testReadObjectIsReader() {
         final Object downcastedInputStream = new InputStreamReader(new ByteArrayInputStream(
-                TEST_JSON.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+                TEST_JSON.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals(TEST_MAP, configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsMalformedReaderContent() throws Exception {
+    void testReadObjectIsMalformedReaderContent() {
         final Object downcastedInputStream = new InputStreamReader(new ByteArrayInputStream(
-                TEST_NOT_JSON.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+                TEST_NOT_JSON.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedInputStream, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsString() throws Exception {
+    void testReadObjectIsString() {
         assertEquals(TEST_MAP, configFormatter.read(TEST_JSON, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsMalformedStringContent() throws Exception {
+    void testReadObjectIsMalformedStringContent() {
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(TEST_NOT_JSON, Map.class).get());
     }
 
     @Test
-    void testReadObjectIsJsonNode() throws Exception {
+    void testReadObjectIsJsonNode() {
         final Object jsonNode = new TextNode(TEST_VALUE);
         assertEquals(TEST_VALUE, configFormatter.read(jsonNode, String.class).get());
     }
@@ -110,13 +110,13 @@ class JacksonConfigFormatterTest {
     }
 
     @Test
-    void testUnsupportedInputType() throws Exception {
+    void testUnsupportedInputType() {
         final Object downcastedDouble = 2.0;
         assertThrows(NoSuchElementException.class, () -> configFormatter.read(downcastedDouble, Map.class).get());
     }
 
     @Test
-    void testWrite() throws Exception {
+    void testWrite() {
         final Object written = configFormatter.write(TEST_MAP);
         assertTrue(written instanceof String);
         assertEquals(TEST_JSON, written);

--- a/formatter-passthrough/pom.xml
+++ b/formatter-passthrough/pom.xml
@@ -5,17 +5,12 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>formatter-passthrough</artifactId>
 
     <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>io.liquorice.config</groupId>
             <artifactId>config-api</artifactId>

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -48,4 +48,12 @@
     <activeProfile>liquorice.nexus</activeProfile>
   </activeProfiles>
 
+  <servers>
+    <server>
+      <id>liquorice.nexus</id>
+      <username>${env.LIQ_NEXUS_USER}</username>
+      <password>${env.LIQ_NEXUS_PASSWORD}</password>
+    </server>
+  </servers>
+
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>io.liquorice</groupId>
         <artifactId>maven-parent-poms</artifactId>
-        <version>1.0.3</version>
+        <version>2.1.2</version>
     </parent>
 
     <groupId>io.liquorice.config</groupId>
     <artifactId>parent</artifactId>
-    <version>0.3.4</version>
+    <version>0.4.0</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -25,11 +25,11 @@
         <module>storage-file-properties</module>
         <module>storage-inmemory</module>
         <module>test-support</module>
+        <module>utils</module>
     </modules>
 
     <properties>
         <gson.version>2.8.5</gson.version>
-        <guava.version>19.0</guava.version>
         <jackson.version>2.9.9</jackson.version>
         <jackson-databind.version>2.9.10.1</jackson-databind.version>
         <junit.jupiter.version>5.3.2</junit.jupiter.version>
@@ -38,7 +38,6 @@
 
     <dependencyManagement>
         <dependencies>
-
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
@@ -53,11 +52,6 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.liquorice.config</groupId>
@@ -87,6 +81,11 @@
             <dependency>
                 <groupId>io.liquorice.config</groupId>
                 <artifactId>test-support</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.liquorice.config</groupId>
+                <artifactId>utils</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+  This file contains some false positive bugs detected by spotbugs. Their
+  false positive nature has been analyzed individually and they have been
+  put here to instruct spotbugs it must ignore them.
+-->
+<FindBugsFilter>
+    <!--
+        Known false positive with "try-with-resources" on java11
+            See: https://github.com/spotbugs/spotbugs/issues/756
+      -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+</FindBugsFilter>

--- a/storage-file-json-gson/pom.xml
+++ b/storage-file-json-gson/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>storage-file-json-gson</artifactId>
@@ -16,11 +16,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -39,6 +34,10 @@
             <groupId>io.liquorice.config</groupId>
             <artifactId>test-support</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.liquorice.config</groupId>
+            <artifactId>utils</artifactId>
         </dependency>
     </dependencies>
 

--- a/storage-file-json-gson/src/test/java/io/liquorice/config/storage/file/json/gson/ReadableGsonFileConfigSpaceTest.java
+++ b/storage-file-json-gson/src/test/java/io/liquorice/config/storage/file/json/gson/ReadableGsonFileConfigSpaceTest.java
@@ -21,13 +21,13 @@ import static io.liquorice.config.test.support.ConfigSpaceTestData.LONG_VALUE;
 import static io.liquorice.config.test.support.ConfigSpaceTestData.STRING_KEY;
 import static io.liquorice.config.test.support.ConfigSpaceTestData.STRING_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.google.common.base.Charsets;
 import com.google.gson.GsonBuilder;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
@@ -58,10 +57,10 @@ class ReadableGsonFileConfigSpaceTest {
     private ReadableGsonFileConfigSpace configSpace;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
         // Initialize seed properties
         final InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(
-                JSON_STRING.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+                JSON_STRING.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 
         final Function<FileChannel, Reader> fileChannelReaderFunction = internalFileChannel -> isr;
 

--- a/storage-file-json-gson/src/test/java/io/liquorice/config/storage/file/json/gson/WritableGsonFileConfigSpaceTest.java
+++ b/storage-file-json-gson/src/test/java/io/liquorice/config/storage/file/json/gson/WritableGsonFileConfigSpaceTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -39,7 +40,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -55,11 +55,11 @@ import io.liquorice.config.formatter.json.gson.GsonConfigFormatter;
 class WritableGsonFileConfigSpaceTest {
 
     private static WritableGsonFileConfigSpace createConfigSpace(final OutputStream outputStream,
-            final FileChannel fileChannel) throws Exception {
+            final FileChannel fileChannel) {
         // Initialize seed properties
         final InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(
-                JSON_STRING.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
-        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, Charsets.UTF_8);
+                JSON_STRING.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
 
         final Function<FileChannel, Reader> fileChannelReaderFunction = internalFileChannel -> isr;
         final Function<FileChannel, Writer> fileChannelWriterFunction = internalFileChannel -> osw;
@@ -88,7 +88,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testUpdateBoolean() throws Exception {
+    void testUpdateBoolean() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -100,7 +100,7 @@ class WritableGsonFileConfigSpaceTest {
         assertEquals(UPDATED_BOOL_VALUE, configSpace.getBooleanRequired(BOOL_KEY));
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertEquals(UPDATED_BOOL_VALUE, jsonObject.get(BOOL_KEY).getAsBoolean());
         assertEquals(DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());
@@ -111,7 +111,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testUpdateDouble() throws Exception {
+    void testUpdateDouble() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -123,7 +123,7 @@ class WritableGsonFileConfigSpaceTest {
         assertEquals(configSpace.getDoubleRequired(DOUBLE_KEY), UPDATED_DOUBLE_VALUE);
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertEquals(BOOL_VALUE, jsonObject.get(BOOL_KEY).getAsBoolean());
         assertEquals(UPDATED_DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());
@@ -134,7 +134,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testUpdateInt() throws Exception {
+    void testUpdateInt() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -146,7 +146,7 @@ class WritableGsonFileConfigSpaceTest {
         assertEquals(configSpace.getIntRequired(INT_KEY), UPDATED_INT_VALUE);
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertEquals(BOOL_VALUE, jsonObject.get(BOOL_KEY).getAsBoolean());
         assertEquals(DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());
@@ -157,7 +157,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testUpdateLong() throws Exception {
+    void testUpdateLong() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -169,7 +169,7 @@ class WritableGsonFileConfigSpaceTest {
         assertEquals(configSpace.getLongRequired(LONG_KEY), UPDATED_LONG_VALUE);
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertEquals(BOOL_VALUE, jsonObject.get(BOOL_KEY).getAsBoolean());
         assertEquals(DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());
@@ -180,7 +180,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testUpdateString() throws Exception {
+    void testUpdateString() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -192,7 +192,7 @@ class WritableGsonFileConfigSpaceTest {
         assertEquals(configSpace.getStringRequired(STRING_KEY), UPDATED_STRING_VALUE);
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertEquals(BOOL_VALUE, jsonObject.get(BOOL_KEY).getAsBoolean());
         assertEquals(DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());
@@ -203,7 +203,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testUpdateObject() throws Exception {
+    void testUpdateObject() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -215,7 +215,7 @@ class WritableGsonFileConfigSpaceTest {
         assertEquals(configSpace.getObjectRequired(COMPLEX_KEY, List.class), UPDATED_COMPLEX_VALUE);
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertEquals(BOOL_VALUE, jsonObject.get(BOOL_KEY).getAsBoolean());
         assertEquals(DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());
@@ -226,7 +226,7 @@ class WritableGsonFileConfigSpaceTest {
     }
 
     @Test
-    void testRemoveProperty() throws Exception {
+    void testRemoveProperty() {
         // Setup mocks
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final WritableGsonFileConfigSpace configSpace = createConfigSpace(baos, mockFileChannel);
@@ -238,7 +238,7 @@ class WritableGsonFileConfigSpaceTest {
         assertFalse(configSpace.hasValue(BOOL_KEY));
 
         // Verify the on disk properties were updated
-        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), Charsets.UTF_8);
+        final Reader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()), StandardCharsets.UTF_8);
         final JsonObject jsonObject = new JsonParser().parse(gson.newJsonReader(isr)).getAsJsonObject();
         assertFalse(jsonObject.has(BOOL_KEY));
         assertEquals(DOUBLE_VALUE, jsonObject.get(DOUBLE_KEY).getAsDouble());

--- a/storage-file-json-jackson/pom.xml
+++ b/storage-file-json-jackson/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>storage-file-json-jackson</artifactId>
@@ -21,11 +21,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -44,6 +39,10 @@
             <groupId>io.liquorice.config</groupId>
             <artifactId>test-support</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.liquorice.config</groupId>
+            <artifactId>utils</artifactId>
         </dependency>
     </dependencies>
 

--- a/storage-file-json-jackson/src/main/java/io/liquorice/config/storage/file/json/jackson/ReadableJacksonFileConfigSpace.java
+++ b/storage-file-json-jackson/src/main/java/io/liquorice/config/storage/file/json/jackson/ReadableJacksonFileConfigSpace.java
@@ -1,21 +1,21 @@
 package io.liquorice.config.storage.file.json.jackson;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static io.liquorice.config.utils.StringUtils.requireNonEmpty;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
-import com.google.common.base.Strings;
-import com.google.common.collect.Sets;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.api.storage.AbstractConfigSpace;
@@ -30,7 +30,7 @@ import io.liquorice.config.formatter.json.jackson.JacksonConfigFormatter;
 public class ReadableJacksonFileConfigSpace extends AbstractConfigSpace {
 
     private static final Function<FileChannel, Reader> DEFAULT_FILE_CHANNEL_READER_FUNCTION = internalFileChannel -> Channels
-            .newReader(checkNotNull(internalFileChannel), Charsets.UTF_8.name());
+            .newReader(requireNonNull(internalFileChannel), StandardCharsets.UTF_8.name());
 
     private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
 
@@ -119,7 +119,7 @@ public class ReadableJacksonFileConfigSpace extends AbstractConfigSpace {
      */
     @Override
     public boolean hasValue(final String key) {
-        return rootNode.hasNonNull(checkNotNull(Strings.emptyToNull(key)));
+        return rootNode.hasNonNull(requireNonEmpty(key));
     }
 
     /**
@@ -148,8 +148,8 @@ public class ReadableJacksonFileConfigSpace extends AbstractConfigSpace {
     }
 
     private JsonNode getNonNullable(final String key) {
-        final JsonNode value = getBackingJsonNode().get(checkNotNull(Strings.emptyToNull(key)));
-        checkNotNull(value);
+        final JsonNode value = getBackingJsonNode().get(requireNonEmpty(key));
+        requireNonNull(value);
         return value;
     }
 
@@ -170,7 +170,7 @@ public class ReadableJacksonFileConfigSpace extends AbstractConfigSpace {
         public Builder() {
             this.configFormatter = new JacksonConfigFormatter.Builder().build();
             this.fileChannelReaderFunction = DEFAULT_FILE_CHANNEL_READER_FUNCTION;
-            this.modulesToRegister = Sets.newHashSet();
+            this.modulesToRegister = new HashSet<>();
             this.objectMapper = DEFAULT_OBJECT_MAPPER;
         }
 
@@ -233,7 +233,7 @@ public class ReadableJacksonFileConfigSpace extends AbstractConfigSpace {
          * @return this
          */
         public Builder withRegisteredModule(final Module module) {
-            this.modulesToRegister.add(checkNotNull(module));
+            this.modulesToRegister.add(requireNonNull(module));
             return this;
         }
 
@@ -257,13 +257,13 @@ public class ReadableJacksonFileConfigSpace extends AbstractConfigSpace {
          *             if there was a problem building
          */
         public ReadableJacksonFileConfigSpace build() throws ConfigurationException {
-            checkNotNull(configFormatter);
-            checkNotNull(fileChannel);
-            checkNotNull(fileChannelReaderFunction);
-            checkNotNull(objectMapper);
+            requireNonNull(configFormatter);
+            requireNonNull(fileChannel);
+            requireNonNull(fileChannelReaderFunction);
+            requireNonNull(objectMapper);
 
             for (final Module module : modulesToRegister) {
-                objectMapper.registerModule(checkNotNull(module));
+                objectMapper.registerModule(requireNonNull(module));
             }
 
             try {

--- a/storage-file-json-jackson/src/test/java/io/liquorice/config/storage/file/json/jackson/ReadableJacksonFileConfigSpaceTest.java
+++ b/storage-file-json-jackson/src/test/java/io/liquorice/config/storage/file/json/jackson/ReadableJacksonFileConfigSpaceTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -37,7 +38,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.exception.ConfigurationException;
@@ -57,10 +57,10 @@ public class ReadableJacksonFileConfigSpaceTest {
     private ReadableJacksonFileConfigSpace configSpace;
 
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup() {
         // Initialize seed properties
         final InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(
-                JSON_STRING.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+                JSON_STRING.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 
         final Function<FileChannel, Reader> fileChannelReaderFunction = internalFileChannel -> isr;
 

--- a/storage-file-json-jackson/src/test/java/io/liquorice/config/storage/file/json/jackson/WritableJacksonFileConfigSpaceTest.java
+++ b/storage-file-json-jackson/src/test/java/io/liquorice/config/storage/file/json/jackson/WritableJacksonFileConfigSpaceTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -40,7 +41,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.formatter.json.jackson.JacksonConfigFormatter;
@@ -52,11 +52,11 @@ import io.liquorice.config.formatter.json.jackson.JacksonConfigFormatter;
 class WritableJacksonFileConfigSpaceTest {
 
     private static WritableJacksonFileConfigSpace createConfigSpace(final OutputStream outputStream,
-            final FileChannel fileChannel) throws Exception {
+            final FileChannel fileChannel) {
         // Initialize seed properties
         final InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(
-                JSON_STRING.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
-        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, Charsets.UTF_8);
+                JSON_STRING.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
 
         final Function<FileChannel, Reader> fileChannelReaderFunction = internalFileChannel -> isr;
         final Function<FileChannel, Writer> fileChannelWriterFunction = internalFileChannel -> osw;

--- a/storage-file-properties/pom.xml
+++ b/storage-file-properties/pom.xml
@@ -6,18 +6,12 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>storage-file-properties</artifactId>
 
     <dependencies>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>io.liquorice.config</groupId>
             <artifactId>config-api</artifactId>
@@ -34,6 +28,10 @@
             <groupId>io.liquorice.config</groupId>
             <artifactId>test-support</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.liquorice.config</groupId>
+            <artifactId>utils</artifactId>
         </dependency>
     </dependencies>
 

--- a/storage-file-properties/src/main/java/io/liquorice/config/storage/file/properties/ReadablePropertiesFileConfigSpace.java
+++ b/storage-file-properties/src/main/java/io/liquorice/config/storage/file/properties/ReadablePropertiesFileConfigSpace.java
@@ -1,16 +1,15 @@
 package io.liquorice.config.storage.file.properties;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static io.liquorice.config.utils.StringUtils.requireNonEmpty;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.function.Function;
-
-import com.google.common.base.Charsets;
-import com.google.common.base.Strings;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.api.storage.AbstractConfigSpace;
@@ -24,7 +23,7 @@ import io.liquorice.config.exception.ConfigurationException;
 public class ReadablePropertiesFileConfigSpace extends AbstractConfigSpace {
 
     private static final Function<FileChannel, Reader> DEFAULT_FILE_CHANNEL_READER_FUNCTION = internalFileChannel -> Channels
-            .newReader(checkNotNull(internalFileChannel), Charsets.UTF_8.name());
+            .newReader(requireNonNull(internalFileChannel), StandardCharsets.UTF_8.name());
 
     private final FileChannel fileChannel;
     private final Function<FileChannel, Reader> fileChannelReaderFunction;
@@ -128,7 +127,7 @@ public class ReadablePropertiesFileConfigSpace extends AbstractConfigSpace {
      */
     @Override
     public boolean hasValue(final String key) {
-        return properties.containsKey(checkNotNull(Strings.emptyToNull(key)));
+        return properties.containsKey(requireNonEmpty(key));
     }
 
     /**
@@ -144,8 +143,8 @@ public class ReadablePropertiesFileConfigSpace extends AbstractConfigSpace {
     }
 
     private Object getNonNullable(final String key) {
-        final Object value = properties.getProperty(checkNotNull(Strings.emptyToNull(key)));
-        checkNotNull(value);
+        final Object value = properties.getProperty(requireNonEmpty(key));
+        requireNonNull(value);
         return value;
     }
 
@@ -212,9 +211,9 @@ public class ReadablePropertiesFileConfigSpace extends AbstractConfigSpace {
          *             if there was a problem building
          */
         public ReadablePropertiesFileConfigSpace build() throws ConfigurationException {
-            checkNotNull(configFormatter);
-            checkNotNull(fileChannel);
-            checkNotNull(fileChannelReaderFunction);
+            requireNonNull(configFormatter);
+            requireNonNull(fileChannel);
+            requireNonNull(fileChannelReaderFunction);
             try {
                 return new ReadablePropertiesFileConfigSpace(this);
             } catch (final IOException e) {

--- a/storage-file-properties/src/test/java/io/liquorice/config/storage/file/properties/ReadablePropertiesFileConfigSpaceTest.java
+++ b/storage-file-properties/src/test/java/io/liquorice/config/storage/file/properties/ReadablePropertiesFileConfigSpaceTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Function;
@@ -35,8 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.google.common.base.Charsets;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.exception.ConfigurationException;
@@ -65,7 +64,7 @@ class ReadablePropertiesFileConfigSpaceTest {
         seedProperties.setProperty(STRING_KEY, STRING_VALUE);
         seedProperties.store(baos, null);
         final InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()),
-                Charsets.UTF_8);
+                StandardCharsets.UTF_8);
 
         final Function<FileChannel, Reader> fileChannelReaderFunction = internalFileChannel -> isr;
 

--- a/storage-file-properties/src/test/java/io/liquorice/config/storage/file/properties/WritablePropertiesFileConfigSpaceTest.java
+++ b/storage-file-properties/src/test/java/io/liquorice/config/storage/file/properties/WritablePropertiesFileConfigSpaceTest.java
@@ -26,6 +26,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.function.Function;
 
@@ -33,8 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.google.common.base.Charsets;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.formatter.passthrough.PassThroughConfigFormatter;
@@ -57,8 +56,8 @@ class WritablePropertiesFileConfigSpaceTest {
         seedProperties.setProperty(STRING_KEY, STRING_VALUE);
         seedProperties.store(baos, null);
         final InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()),
-                Charsets.UTF_8);
-        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, Charsets.UTF_8);
+                StandardCharsets.UTF_8);
+        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
 
         final Function<FileChannel, Reader> fileChannelReaderFunction = internalFileChannel -> isr;
         final Function<FileChannel, Writer> fileChannelWriterFunction = internalFileChannel -> osw;

--- a/storage-inmemory/pom.xml
+++ b/storage-inmemory/pom.xml
@@ -6,18 +6,12 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>storage-inmemory</artifactId>
 
     <dependencies>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>io.liquorice.config</groupId>
             <artifactId>config-api</artifactId>
@@ -34,6 +28,10 @@
             <groupId>io.liquorice.config</groupId>
             <artifactId>test-support</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.liquorice.config</groupId>
+            <artifactId>utils</artifactId>
         </dependency>
     </dependencies>
 

--- a/storage-inmemory/src/main/java/io/liquorice/config/storage/inmemory/ReadableMapConfigSpace.java
+++ b/storage-inmemory/src/main/java/io/liquorice/config/storage/inmemory/ReadableMapConfigSpace.java
@@ -1,11 +1,10 @@
 package io.liquorice.config.storage.inmemory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static io.liquorice.config.utils.StringUtils.requireNonEmpty;
+import static java.util.Objects.requireNonNull;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.api.storage.AbstractConfigSpace;
@@ -29,8 +28,8 @@ public class ReadableMapConfigSpace extends AbstractConfigSpace {
      *            the properties to seed this {@link ReadableMapConfigSpace} with
      */
     public ReadableMapConfigSpace(final ConfigFormatter configFormatter, final Map<String, Object> properties) {
-        super(checkNotNull(configFormatter));
-        map = Maps.newHashMap(checkNotNull(properties));
+        super(requireNonNull(configFormatter));
+        map = new HashMap<>(requireNonNull(properties));
     }
 
     /**
@@ -90,7 +89,7 @@ public class ReadableMapConfigSpace extends AbstractConfigSpace {
      */
     @Override
     public boolean hasValue(final String key) {
-        return map.containsKey(checkNotNull(Strings.emptyToNull(key)));
+        return map.containsKey(requireNonEmpty(key));
     }
 
     /**
@@ -107,8 +106,6 @@ public class ReadableMapConfigSpace extends AbstractConfigSpace {
 
 
     private Object getNonNullable(final String key) {
-        final Object value = map.get(checkNotNull(Strings.emptyToNull(key)));
-        checkNotNull(value);
-        return value;
+        return requireNonNull(map.get(requireNonEmpty(key)));
     }
 }

--- a/storage-inmemory/src/main/java/io/liquorice/config/storage/inmemory/WritableMapConfigSpace.java
+++ b/storage-inmemory/src/main/java/io/liquorice/config/storage/inmemory/WritableMapConfigSpace.java
@@ -1,10 +1,9 @@
 package io.liquorice.config.storage.inmemory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static io.liquorice.config.utils.StringUtils.requireNonEmpty;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
-
-import com.google.common.base.Strings;
 
 import io.liquorice.config.api.formatter.ConfigFormatter;
 import io.liquorice.config.api.storage.WritableConfigSpace;
@@ -18,7 +17,7 @@ public class WritableMapConfigSpace extends ReadableMapConfigSpace implements Wr
      * {@inheritDoc}
      */
     public void remove(final String key) {
-        checkNotNull(Strings.emptyToNull(key));
+        requireNonEmpty(key);
 
         getBackingMap().remove(key);
     }
@@ -32,7 +31,7 @@ public class WritableMapConfigSpace extends ReadableMapConfigSpace implements Wr
      *            the properties to seed this {@link WritableMapConfigSpace} with
      */
     public WritableMapConfigSpace(final ConfigFormatter configFormatter, final Map<String, Object> properties) {
-        super(checkNotNull(configFormatter), checkNotNull(properties));
+        super(requireNonNull(configFormatter), requireNonNull(properties));
     }
 
     /**
@@ -72,8 +71,8 @@ public class WritableMapConfigSpace extends ReadableMapConfigSpace implements Wr
      */
     @Override
     public void setObject(final String key, final Object value) {
-        checkNotNull(Strings.emptyToNull(key));
-        checkNotNull(value, "Null value. Call ConfigSpace#remove to instead.");
+        requireNonEmpty(key);
+        requireNonNull(value, "Null value. Call ConfigSpace#remove to instead.");
 
         getBackingMap().put(key, getConfigFormatter().write(value));
     }

--- a/storage-inmemory/src/test/java/io/liquorice/config/storage/inmemory/Fixtures.java
+++ b/storage-inmemory/src/test/java/io/liquorice/config/storage/inmemory/Fixtures.java
@@ -15,20 +15,17 @@ import static io.liquorice.config.test.support.ConfigSpaceTestData.STRING_VALUE;
 
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-
 public final class Fixtures {
 
     private Fixtures() {
 
     }
 
-    public static final Map<String, Object> SEED_PROPERTIES = ImmutableMap.<String, Object>builder()
-            .put(BOOL_KEY, BOOL_VALUE)
-            .put(DOUBLE_KEY, DOUBLE_VALUE)
-            .put(INT_KEY, INT_VALUE)
-            .put(LONG_KEY, LONG_VALUE)
-            .put(STRING_KEY, STRING_VALUE)
-            .put(COMPLEX_KEY, COMPLEX_VALUE)
-            .build();
+    public static final Map<String, Object> SEED_PROPERTIES = Map.of(
+            BOOL_KEY, BOOL_VALUE,
+            DOUBLE_KEY, DOUBLE_VALUE,
+            INT_KEY, INT_VALUE,
+            LONG_KEY, LONG_VALUE,
+            STRING_KEY, STRING_VALUE,
+            COMPLEX_KEY, COMPLEX_VALUE);
 }

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -5,17 +5,9 @@
     <parent>
         <groupId>io.liquorice.config</groupId>
         <artifactId>parent</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>test-support</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/test-support/src/main/java/io/liquorice/config/test/support/ConfigFormatterTestData.java
+++ b/test-support/src/main/java/io/liquorice/config/test/support/ConfigFormatterTestData.java
@@ -3,9 +3,6 @@ package io.liquorice.config.test.support;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 /**
  * Created by mthorpe on 12/17/16.
  */
@@ -13,8 +10,8 @@ public class ConfigFormatterTestData {
 
     public static final String TEST_KEY = "test";
     public static final String TEST_VALUE = "this is a test string";
-    public static final List<String> TEST_LIST = ImmutableList.of("string1", "string2");
-    public static final Map<String, String> TEST_MAP = ImmutableMap.of(TEST_KEY, TEST_VALUE);
+    public static final List<String> TEST_LIST = List.of("string1", "string2");
+    public static final Map<String, String> TEST_MAP = Map.of(TEST_KEY, TEST_VALUE);
 
     public static final String TEST_JSON = "{" + //
             String.format("\"%s\":\"%s\"", TEST_KEY, TEST_VALUE) + //

--- a/test-support/src/main/java/io/liquorice/config/test/support/ConfigSpaceTestData.java
+++ b/test-support/src/main/java/io/liquorice/config/test/support/ConfigSpaceTestData.java
@@ -2,9 +2,6 @@ package io.liquorice.config.test.support;
 
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
 /**
  * Created by mthorpe on 12/13/16.
  */
@@ -23,21 +20,21 @@ public final class ConfigSpaceTestData {
     public static final int INT_VALUE = 7;
     public static final long LONG_VALUE = 17L;
     public static final String STRING_VALUE = "test string";
-    public static final List<String> COMPLEX_VALUE = ImmutableList.of(BOOL_KEY, DOUBLE_KEY);
+    public static final List<String> COMPLEX_VALUE = List.of(BOOL_KEY, DOUBLE_KEY);
 
     public static final boolean DEFAULT_BOOL_VALUE = false;
     public static final double DEFAULT_DOUBLE_VALUE = 2.4;
     public static final int DEFAULT_INT_VALUE = 18;
     public static final long DEFAULT_LONG_VALUE = 24L;
     public static final String DEFAULT_STRING_VALUE = "default test value";
-    public static final List<String> DEFAULT_COMPLEX_VALUE = ImmutableList.of(INT_KEY, LONG_KEY);
+    public static final List<String> DEFAULT_COMPLEX_VALUE = List.of(INT_KEY, LONG_KEY);
 
     public static final boolean UPDATED_BOOL_VALUE = false;
     public static final double UPDATED_DOUBLE_VALUE = 14.5;
     public static final int UPDATED_INT_VALUE = 9;
     public static final long UPDATED_LONG_VALUE = 31L;
     public static final String UPDATED_STRING_VALUE = "updated string";
-    public static final List<String> UPDATED_COMPLEX_VALUE = ImmutableList.of(INT_KEY, STRING_KEY);
+    public static final List<String> UPDATED_COMPLEX_VALUE = List.of(INT_KEY, STRING_KEY);
 
     public static final String JSON_STRING = "{" + //
             String.format("\"%s\":%s,", BOOL_KEY, Boolean.toString(BOOL_VALUE)) + //

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -9,13 +9,6 @@
         <version>0.4.0</version>
     </parent>
 
-    <artifactId>config-api</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>io.liquorice.config</groupId>
-            <artifactId>config-exceptions</artifactId>
-        </dependency>
-    </dependencies>
+    <artifactId>utils</artifactId>
 
 </project>

--- a/utils/src/main/java/io/liquorice/config/utils/StringUtils.java
+++ b/utils/src/main/java/io/liquorice/config/utils/StringUtils.java
@@ -1,0 +1,50 @@
+package io.liquorice.config.utils;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utilities for validating and manipulating strings
+ *
+ * @author mthorpe
+ */
+public class StringUtils {
+
+    /**
+     * Verifies that {@code val} is neither null nor empty
+     *
+     * @param val
+     *            the value to test
+     * @return {@code val}
+     * @throws IllegalArgumentException
+     *             if {@code val} is null or empty
+     */
+    public static String requireNonEmpty(final String val) {
+        return requireNonNull(emptyToNull(val));
+    }
+
+    /**
+     * Verifies that {@code val} is neither null nor empty
+     * 
+     * @param val
+     *            the value to test
+     * @param message
+     *            the message to pass as the exception if {@code val} is null or empty
+     * @return {@code val}
+     * @throws IllegalArgumentException
+     *             if {@code val} is null or empty
+     */
+    public static String requireNonEmpty(final String val, final String message) {
+        return requireNonNull(emptyToNull(val), message);
+    }
+
+    /**
+     * Safely converts empty strings to nulls
+     *
+     * @param val
+     *            the value to convert
+     * @return {@code val} if non-null and non-empty, else null
+     */
+    public static String emptyToNull(final String val) {
+        return "".equals(val) ? null : val;
+    }
+}


### PR DESCRIPTION
Upgrades to the java11 parent pom and removes guava as a direct dependency